### PR TITLE
fix: Channel.clientをunownedからweakに変更してクラッシュを防止

### DIFF
--- a/Source/Classes/Channel.swift
+++ b/Source/Classes/Channel.swift
@@ -46,7 +46,7 @@ open class Channel: Hashable, Equatable {
     
     /// Subscribed
     open var isSubscribed : Bool {
-        return client.subscribed(identifier: identifier)
+        return client?.subscribed(identifier: identifier) ?? false
     }
     
     /// A block called when a message has been received on this channel.
@@ -152,6 +152,7 @@ open class Channel: Hashable, Equatable {
     ///             message.
     @discardableResult
     open func action(_ name: String, with params: [String: Any]? = nil) -> Swift.Error? {
+        guard let client = client else { return TransmitError.notConnected }
         do {
           try (client.action(name, on: self, with: params))
         // Consume the error and return false if the error is a not subscribed
@@ -178,7 +179,7 @@ open class Channel: Hashable, Equatable {
     /// channel.subscribe()
     /// ```
     open func subscribe() {
-        client.subscribe(self)
+        client?.subscribe(self)
     }
     
     /// Unsubscribe from the channel on the server.
@@ -189,11 +190,11 @@ open class Channel: Hashable, Equatable {
     /// channel.unsubscribe()
     /// ```
     open func unsubscribe() {
-        client.unsubscribe(self)
+        client?.unsubscribe(self)
     }
     
     internal var onReceiveActionHooks: Dictionary<String, OnReceiveClosure> = Dictionary()
-    internal unowned var client: ActionCableClient
+    internal weak var client: ActionCableClient?
     internal var actionBuffer: Array<SwiftAction> = Array()
     public var hashValue: Int {
         get {
@@ -265,7 +266,7 @@ extension Channel {
 
 extension Channel: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "ActionCable.Channel<\(hashValue)>(name: \"\(self.name)\" subscribed: \(self.isSubscribed))"
+        return "ActionCable.Channel<\(hashValue)>(name: \"\(self.name)\" subscribed: \(self.isSubscribed) client: \(client == nil ? "nil" : "active"))"
     }
 }
 


### PR DESCRIPTION
## Summary
- `Channel` の `internal unowned var client: ActionCableClient` を `internal weak var client: ActionCableClient?` に変更
- `ActionCableClient` が先に解放された後に `Channel` のプロパティ/メソッドにアクセスしてもクラッシュしなくなる

## 原因
`Channel` は `ActionCableClient` への参照を `unowned` で保持しているが、非同期タスクやタイマーによって `ActionCableClient` が先に解放されるケースがある。その状態で `channel.isSubscribed` 等にアクセスすると `swift_abortRetainUnowned` でクラッシュする。

whoo-ios 本体で実際にクラッシュが発生: https://github.com/LinQTeam/whoo-ios/pull/5743

## 変更箇所

| 箇所 | 変更前 | 変更後 |
|------|--------|--------|
| `client` プロパティ | `unowned var client: ActionCableClient` | `weak var client: ActionCableClient?` |
| `isSubscribed` | `client.subscribed(...)` | `client?.subscribed(...) ?? false` |
| `action()` | 直接 `client.action(...)` | `guard let client` で nil チェック → `TransmitError.notConnected` |
| `subscribe()` | `client.subscribe(self)` | `client?.subscribe(self)` |
| `unsubscribe()` | `client.unsubscribe(self)` | `client?.unsubscribe(self)` |
| `debugDescription` | - | `client` の生存状態を表示 |

## weak化の安全性

`ActionCableClient` は `channels` / `unconfirmedChannels` 辞書で `Channel` を保持しており、`Channel` → `ActionCableClient` は逆参照。`weak` にしても循環参照の解消という点で正しく、`ActionCableClient` が生存している間は正常に動作する。解放済みの場合は各メソッドが安全にno-opまたはエラーを返す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)